### PR TITLE
Lang typo - MyAlerts and TYL System integration

### DIFF
--- a/inc/plugins/thankyoulike.php
+++ b/inc/plugins/thankyoulike.php
@@ -148,7 +148,7 @@ function tyl_myalerts_integrate(){
 				$alertTypeManager->add($alertType);	
 			}
 
-			flash_message("MyAlerts and TYL System are integrated successfully", 'success');
+			flash_message("MyAlerts and TYL System were integrated successfully!", 'success');
 			admin_redirect('index.php?module=config-plugins');			
 		}	
 	}


### PR DESCRIPTION
For me, this sounds better. I think it is useles to use lang_string for other languages in this case, anyway I can modify my PR and add it.